### PR TITLE
Heroku Deployment Addons

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
+      racc (~> 1.4)
     orderly (0.1.1)
       capybara (>= 1.1)
       rspec (>= 2.14)
@@ -194,7 +196,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    thor (1.1.0)
+    thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
     turbolinks (5.2.1)
@@ -217,6 +219,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,5 @@
 //
 //= require rails-ujs
 //= require activestorage
-= require turbolinks
+//= require turbolinks
 //= require_tree .


### PR DESCRIPTION
In order to deploy to Heroku I needed to update some gems in our Gemfile and undo the changes we made to the turbolinks line of code in `app/assets/javascripts/application.js`. 

But once we merge this into main, and I think you all re-run `$ bundle install` on your locals, and do the Heroku setup I slacked to you all we should all be able to deploy to the Heroku app.