### PR TITLE
Fix ordering of items ready to ship: by invoice creation date on Merchant Dashboard 

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -15,9 +15,10 @@ class Merchant < ApplicationRecord
   end
 
   def items_not_shipped
-    items.joins(:invoice_items, :invoices)
+    items.joins(invoice_items: :invoice)
+    .select('items.*, invoices.created_at as invoice_created, invoices.id as invoice_id')
     .where.not("invoice_items.status = ?", 2)
-    .order('invoices.created_at')
+    .order('invoices.created_at asc')
   end
 
   def top_five_items
@@ -39,4 +40,4 @@ class Merchant < ApplicationRecord
   #   .created_at
   #   .strftime("%A, %B %d, %Y")
   # end
-end 
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -2,17 +2,18 @@
 <%= link_to "My items", merchant_items_path(@merchant.id) %>
 <%= link_to "My invoices", merchant_invoices_path(@merchant.id) %>
 
+<h3>Favorite Customers</h3>
+<ol>
 <% @merchant.top_5_customers.each do |customer| %>
   <div id="customer<%= customer.id %>">
-  <p><%= customer.first_name %> <%= customer.last_name %> <%= customer.transaction_count %></p>
+  <li><%= customer.first_name %> <%= customer.last_name %> - <%= customer.transaction_count %> purchases</li>
   </div>
 <% end %>
+</ol>
 
 <h3>Items Ready to Ship</h3>
 <% @merchant.items_not_shipped.each do |item| %>
-  <% item.invoice_items.each do |invoice_item| %>
-  <div id="invoiceitem<%=invoice_item.id%>">
-    <p><%= item.name %> - Invoice#<%= link_to invoice_item.invoice_id, merchant_invoice_path(@merchant.id, invoice_item.invoice_id) %> - <%= invoice_item.invoice_creation_date %></p>
+  <div id="item<%=item.id%>">
+    <li><%= item.name %> - Invoice#<%= link_to item.invoice_id, merchant_invoice_path(@merchant.id, item.invoice_id) %> - <%= item.invoice_created.strftime("%A, %B %d,%Y") %></li>
   </div>
-  <% end %>
 <% end %>

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -167,19 +167,19 @@ RSpec.describe 'Merchant Dashboard' do
     end
 
     scenario 'visitor sees date of invoice creation next to each item' do
-      expect(page).to have_content(@invoice_item_1.invoice_creation_date)
-      expect(page).to have_content(@invoice_item_2.invoice_creation_date)
-      expect(page).to have_content(@invoice_item_3.invoice_creation_date)
-      expect(page).to have_content(@invoice_item_4.invoice_creation_date)
-      expect(page).to have_content(@invoice_item_5.invoice_creation_date)
+      expect(page).to have_content(@invoice_1.created_at.strftime("%A, %B %d,%Y"))
+      expect(page).to have_content(@invoice_2.created_at.strftime("%A, %B %d,%Y"))
+      expect(page).to have_content(@invoice_3.created_at.strftime("%A, %B %d,%Y"))
+      expect(page).to have_content(@invoice_4.created_at.strftime("%A, %B %d,%Y"))
+      expect(page).to have_content(@invoice_5.created_at.strftime("%A, %B %d,%Y"))
     end
 
     scenario 'visitor sees list ordered from oldest to newest' do
-      first = find("#invoiceitem#{@invoice_item_1.id}")
-      second = find("#invoiceitem#{@invoice_item_4.id}")
-      third = find("#invoiceitem#{@invoice_item_5.id}")
-      fourth = find("#invoiceitem#{@invoice_item_2.id}")
-      fifth = find("#invoiceitem#{@invoice_item_3.id}")
+      first = find("#item#{@item_1.id}")
+      second = find("#item#{@item_4.id}")
+      third = find("#item#{@item_5.id}")
+      fourth = find("#item#{@item_2.id}")
+      fifth = find("#item#{@item_3.id}")
       expect(first).to appear_before(second)
       expect(second).to appear_before(third)
       expect(third).to appear_before(fourth)

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Merchant do
     end
 
     describe '#items_not_shipped' do
-      it 'returns unshipped items ordered by their invoice creation date' do
+      it 'returns unshipped items ordered by their invoice creation date least recent' do
         expect(@merchant_1.items_not_shipped).to eq([@item_1, @item_4, @item_5, @item_2, @item_3])
       end
     end


### PR DESCRIPTION
Originally the Merchant Dashboard was not ordering correctly;

Refactored the active record in items_not_shipped to order by invoice.created_at ASCENDING!
Removed the nested iteration in the view to not need to use invoice items because the active record in items_not_shipped allows us to just call things on item in the view! 

Also- added a few things to the view to reflect the mock views given to us, i.e. Favorite Customers