### PR TITLE
Item Status Update Select Menu on Invoice Show Page

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -12,9 +12,10 @@ class InvoicesController < ApplicationController
   end
 
   def update
-    @item = Item.find(params[:item_id])
-
-    @item.update(status: params[:status].to_i)
+    if params[:item_id]
+      @item = Item.find(params[:item_id])
+      @item.update(status: params[:status].to_i)
+    end
 
     redirect_to merchant_invoice_path(params[:merchant_id], params[:id])
   end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -12,9 +12,14 @@ class InvoicesController < ApplicationController
   end
 
   def update
-    if params[:item_id]
+    @invoice = Invoice.find(params[:id])
+
+    if params[:status]["enabled"]
       @item = Item.find(params[:item_id])
-      @item.update(status: params[:status].to_i)
+      @item.update(status: 0)
+    elsif params[:status]['disabled']
+      @item = Item.find(params[:item_id])
+      @item.update(status: 1)
     end
 
     redirect_to merchant_invoice_path(params[:merchant_id], params[:id])

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -6,8 +6,16 @@ class InvoicesController < ApplicationController
   end
 
   def show
-    @invoice = Invoice.find(params[:id])
+    @invoice        = Invoice.find(params[:id])
     @merchant_items = @invoice.items_by_merchant(params[:merchant_id])
-    @total_revenue = @invoice.total_revenue_by_merchant(params[:merchant_id])
+    @total_revenue  = @invoice.total_revenue_by_merchant(params[:merchant_id])
+  end
+
+  def update
+    @item = Item.find(params[:item_id])
+
+    @item.update(status: params[:status].to_i)
+
+    redirect_to merchant_invoice_path(params[:merchant_id], params[:id])
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -17,6 +17,8 @@ class Invoice < ApplicationRecord
   end
 
   def total_revenue_by_merchant(merchant_id)
-    items_by_merchant(merchant_id).pluck(Arel.sql("invoice_items.unit_price * invoice_items.quantity")).sum
+    items_by_merchant(merchant_id)
+    .pluck(Arel.sql("invoice_items.unit_price * invoice_items.quantity"))
+    .sum
   end
 end

--- a/app/views/invoices/index.html.erb
+++ b/app/views/invoices/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @invoices.each do |invoice| %>
   <div id="invoice<%= invoice.id %>">
-    <p><%= link_to invoice.id, merchant_invoices_path(@merchant.id, invoice.id) %></p>
+    <p><%= link_to invoice.id, merchant_invoice_path(@merchant.id, "#{invoice.id}") %></p>
   </div>
 
 <% end %>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -13,8 +13,16 @@
     <% item.invoice_items.each do |invoice_item| %>
       <p>Unit Price: <%= invoice_item.unit_price %> </p>
       <p>Quantity: <%= invoice_item.quantity %> </p>
-      <p>Status: <%= invoice_item.status %> </p>
+      <p>Invoice Status: <%= invoice_item.status %> </p>
     <% end %>
+    <p> <%= form_with url: merchant_invoice_path(item.merchant_id, @invoice.id), method: :patch, local: true do |f| %>
+      <%= f.hidden_field :item_id, value: item.id %>
+      <%= f.label :status, "Status"  %>
+      <%= f.select :status, [["Enabled", 'enabled'], ["Disabled", 'disabled']], selected: "#{item.status}" %>
+      <%= f.submit "Update Item Status" %>
+      <% end %>
+
+    </p>
   </div>
 <% end %>
 

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe 'Merchant Invoices Index Page', type: :feature do
   end
 
   scenario 'visitor sees each invoice id number links to the merchant invoice show page' do
-    expect(page).to have_link("#{invoice_1.id}", href: merchant_invoices_path(merchant_1.id, invoice_1.id))
-    expect(page).to have_link("#{invoice_2.id}", href: merchant_invoices_path(merchant_1.id, invoice_2.id))
-    expect(page).to have_link("#{invoice_3.id}", href: merchant_invoices_path(merchant_1.id, invoice_3.id))
+    expect(page).to have_link("#{invoice_1.id}", href: merchant_invoice_path(merchant_1.id, invoice_1.id))
+    expect(page).to have_link("#{invoice_2.id}", href: merchant_invoice_path(merchant_1.id, invoice_2.id))
+    expect(page).to have_link("#{invoice_3.id}", href: merchant_invoice_path(merchant_1.id, invoice_3.id))
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
 
         expect(current_path).to eq(merchant_invoice_path(merchant_1.id, invoice_1.id))
         expect(page).to have_field('Status', with: 'enabled')
+
       end
     end
   end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
   let!(:merchant_2) {Merchant.create!(name: 'Deb Millhouse')}
 
   let!(:item_1) {merchant_1.items.create!(name: "Necklace", description: "A thing around your neck", unit_price: 150, status: 1)}
-  let!(:item_2) {merchant_1.items.create!(name: "Bracelet", description: "A thing around your wrist", unit_price: 300,)}
+  let!(:item_2) {merchant_1.items.create!(name: "Bracelet", description: "A thing around your wrist", unit_price: 300, status: 0)}
   let!(:item_3) {merchant_2.items.create!(name: "Earrings", description: "A thing around your ears", unit_price: 220)}
   let!(:item_4) {merchant_2.items.create!(name: "Button", description: "A thing for your pants", unit_price: 150)}
 
@@ -73,7 +73,6 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
 
   describe 'item status update field' do
     scenario 'merchant sees item status select field  and submit button next to each item' do
-      expect(page).to have_field('Status')
       within "#item#{item_1.id}" do
         expect(page).to have_field('Status', with: 'disabled')
         expect(page).to have_button("Update Item Status")
@@ -85,7 +84,24 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
       end
     end
 
-    scenario 'the item select field is populated by item status and changes when updated'
+    scenario 'the item select field is populated by item status and changes when updated' do
+      save_and_open_page
+
+      within "#item#{item_1.id}" do
+        expect(page).to have_field('Status', with: 'disabled')
+        expect(page).to have_button("Update Item Status")
+
+        select "Enabled", from: "Status"
+        click_button("Update Item Status")
+
+        expect(current_path).to eq(merchant_invoice_path(merchant_1.id, invoice_1.id))
+        expect(page).to have_field('Status', with: 'enabled')
+        expect(page).to have_button("Update Item Status")
+      end
+
+      save_and_open_page
+
+    end
   end
   #   As a merchant
   # When I visit my merchant invoice show page

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
   let!(:merchant_1) {Merchant.create!(name: 'Ron Swanson')}
   let!(:merchant_2) {Merchant.create!(name: 'Deb Millhouse')}
 
-  let!(:item_1) {merchant_1.items.create!(name: "Necklace", description: "A thing around your neck", unit_price: 150)}
-  let!(:item_2) {merchant_1.items.create!(name: "Bracelet", description: "A thing around your wrist", unit_price: 300)}
+  let!(:item_1) {merchant_1.items.create!(name: "Necklace", description: "A thing around your neck", unit_price: 150, status: 1)}
+  let!(:item_2) {merchant_1.items.create!(name: "Bracelet", description: "A thing around your wrist", unit_price: 300,)}
   let!(:item_3) {merchant_2.items.create!(name: "Earrings", description: "A thing around your ears", unit_price: 220)}
   let!(:item_4) {merchant_2.items.create!(name: "Button", description: "A thing for your pants", unit_price: 150)}
 
@@ -70,4 +70,33 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
       expect(page).to have_content(total_revenue)
     end
   end
+
+  describe 'item status update field' do
+    scenario 'merchant sees item status select field  and submit button next to each item' do
+      expect(page).to have_field('Status')
+      within "#item#{item_1.id}" do
+        expect(page).to have_field('Status', with: 'disabled')
+        expect(page).to have_button("Update Item Status")
+      end
+
+      within "#item#{item_2.id}" do
+        expect(page).to have_field('Status', with: 'enabled')
+        expect(page).to have_button("Update Item Status")
+      end
+    end
+
+    scenario 'the item select field is populated by item status and changes when updated'
+  end
+  #   As a merchant
+  # When I visit my merchant invoice show page
+  # I see that each invoice item status is a select field
+  # And I see that the invoice item's current status is selected
+  # When I click this select field,
+  # Then I can select a new status for the Item,
+  # And next to the select field I see a button to "Update Item Status"
+  # When I click this button
+  # I am taken back to the merchant invoice show page
+  # And I see that my Item's status has now been updated
+
+
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -94,7 +94,14 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
 
         expect(current_path).to eq(merchant_invoice_path(merchant_1.id, invoice_1.id))
         expect(page).to have_field('Status', with: 'enabled')
+        expect(page).to have_no_field('Status', with: 'disabled')
 
+        select "Disabled", from: "Status"
+        click_button("Update Item Status")
+
+        expect(current_path).to eq(merchant_invoice_path(merchant_1.id, invoice_1.id))
+        expect(page).to have_field('Status', with: 'disabled')
+        expect(page).to have_no_field('Status', with: 'enabled')
       end
     end
   end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -85,8 +85,6 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
     end
 
     scenario 'the item select field is populated by item status and changes when updated' do
-      save_and_open_page
-
       within "#item#{item_1.id}" do
         expect(page).to have_field('Status', with: 'disabled')
         expect(page).to have_button("Update Item Status")
@@ -96,11 +94,7 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
 
         expect(current_path).to eq(merchant_invoice_path(merchant_1.id, invoice_1.id))
         expect(page).to have_field('Status', with: 'enabled')
-        expect(page).to have_button("Update Item Status")
       end
-
-      save_and_open_page
-
     end
   end
   #   As a merchant

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -98,16 +98,4 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
       end
     end
   end
-  #   As a merchant
-  # When I visit my merchant invoice show page
-  # I see that each invoice item status is a select field
-  # And I see that the invoice item's current status is selected
-  # When I click this select field,
-  # Then I can select a new status for the Item,
-  # And next to the select field I see a button to "Update Item Status"
-  # When I click this button
-  # I am taken back to the merchant invoice show page
-  # And I see that my Item's status has now been updated
-
-
 end


### PR DESCRIPTION
Features:
- Next to each item on merchant-invoice show page there is a select drop down menu
- The drop down menu is pre-populated with the item status (disabled/enabled)
- The menu has two options: enabled/disabled
- Next to the menu is a button. When clicked it updates the status of the item to the option selected in dropdown menu and reloads page.

Test:
- Tests posting at 100% for both features and models
- Test show page view for content display and button behavior
- Test both enable and disable params path

Fix:
- Routing error to invoice-show page (Previously sometimes would route to `/invoices.:invoice_id` rather than `/invoices/:invoice_id`)