### PR TITLE
Fix: Remove separate ordering method and add active record order to i…

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DashboardController < ApplicationController
   def index
     @top_5 = Customer.top_5
-    @incomplete_invoices = Invoice.incomplete_invoices.order_by_created_at_old_to_new
+    @incomplete_invoices = Invoice.incomplete_invoices
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -24,13 +24,9 @@ class Invoice < ApplicationRecord
 
   def self.incomplete_invoices
     joins(:invoice_items)
-    .select('invoices.*')
     .where.not('invoice_items.status = ?', 2)
+    .select('invoices.*')
     .group('invoices.id')
-    .distinct
-  end
-
-  def self.order_by_created_at_old_to_new
-    self.order(:created_at)
+    .order(:created_at)
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -55,14 +55,8 @@ RSpec.describe Invoice do
   describe 'class methods' do
     describe '.incomplete_invoices' do
       it 'returns invoices only with items that are packaged or pending' do
-        expect(Invoice.incomplete_invoices).to eq([invoice_1, invoice_2])
+        expect(Invoice.incomplete_invoices).to eq([invoice_2, invoice_1])
         expect(Invoice.incomplete_invoices).to_not include(invoice_3)
-      end
-    end
-
-    describe '.order_by_created_at_old_to_new' do
-      it 'orders invoices from oldest to newest by created_at attribute' do
-        expect(Invoice.order_by_created_at_old_to_new).to eq([invoice_3, invoice_2, invoice_1])
       end
     end
   end


### PR DESCRIPTION
…ncomplete invoices method

Final fix for this method that was giving us a hard time. Added active record order to the method so we can get rid of another whole method and adjusted test expectations accordingly. 