### PR TITLE
Merchant Bulk Discount Delete

### DIFF
--- a/app/controllers/merchants/bulk_discounts_controller.rb
+++ b/app/controllers/merchants/bulk_discounts_controller.rb
@@ -19,6 +19,12 @@ class Merchants::BulkDiscountsController < ApplicationController
     redirect_to merchant_bulk_discounts_path(merchant.id)
   end
 
+  def destroy
+    merchant = Merchant.find(params[:merchant_id])
+    merchant.bulk_discounts.delete(params[:id])
+    redirect_to merchant_bulk_discounts_path(merchant.id)
+  end
+
   private
 
   def discount_params

--- a/app/views/merchants/bulk_discounts/index.html.erb
+++ b/app/views/merchants/bulk_discounts/index.html.erb
@@ -1,7 +1,11 @@
 <h3>Current Discounts</h3>
 <% @bulk_discounts.each do |discount| %>
 <div id="discount<%=discount.id%>"
-  <li><%= number_to_percentage(discount.percentage_discount, precision: 0) %> off - <%= discount.quantity_threshold %> or more of one item - <%= link_to "Link to Discount ##{discount.id}", merchant_bulk_discount_path(discount.merchant_id, discount.id) %></li>
+  <li><%= number_to_percentage(discount.percentage_discount, precision: 0) %> off -
+  <%= discount.quantity_threshold %> or more of one item -
+  <%= link_to "Link to Discount ##{discount.id}", merchant_bulk_discount_path(discount.merchant_id, discount.id) %>
+  <%= link_to "Delete ##{discount.id}", merchant_bulk_discount_path(discount.merchant_id, discount.id), method: :delete  %>
+  </li>
 <% end %>
 </div>
 

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -67,4 +67,13 @@ RSpec.describe 'Bulk Discounts Index' do
     expect(page).to have_content(30)
     expect(page).to have_content(35)
   end
+
+  scenario 'merchant sees link to delete each discount' do
+    expect(page).to have_content(discount_1.percentage_discount)
+
+    click_link("Delete ##{discount_1.id}")
+    
+    expect(current_path).to eq(merchant_bulk_discounts_path(merchant_1.id))
+    expect(page).to_not have_content(discount_1.percentage_discount)
+  end
 end

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -70,9 +70,8 @@ RSpec.describe 'Bulk Discounts Index' do
 
   scenario 'merchant sees link to delete each discount' do
     expect(page).to have_content(discount_1.percentage_discount)
-
     click_link("Delete ##{discount_1.id}")
-    
+
     expect(current_path).to eq(merchant_bulk_discounts_path(merchant_1.id))
     expect(page).to_not have_content(discount_1.percentage_discount)
   end


### PR DESCRIPTION
Tests: 
- Feature test for Merchant BD Index to have functional link to delete a discount 

Controllers: 
- #destroy action to merchants/bulk_discounts_controller.rb 

Features: 
- Link to delete a discount from Merchant BD Index, clicking link deletes discount and stays on same page. 